### PR TITLE
Actually build the superseded packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,18 +9,14 @@ Build-Depends: debhelper (>= 7),
                python-sphinx,
                python-prettytable,
                python-dev,
-               python-flake8,
-               python-pytest,
-               python-unittest2,
-               devscripts
 Standards-Version: 3.9.2
 
 Package: rjil-cicd
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}
-Provides: ${rjil:pkgs}
-Conflicts: ${rjil:pkgs}
-Replaces: ${rjil:pkgs}
+#Provides: ${rjil:pkgs}
+#Conflicts: ${rjil:pkgs}
+#Replaces: ${rjil:pkgs}
 Description: Monolithic OpenStack deb package
  This is a monolithic deb package comprising of the following openstack modules
  * python-cincerclient
@@ -34,13 +30,115 @@ Description: Monolithic OpenStack deb package
 
 Package: ironic-api
 Architecture: all
-Depends: rjil-cicd
-Description: ironic-api server package
- Automatically generated server package for ironic-api
+Depends: rjil-cicd (=${binary:Version})
+Description: ironic-api package
+ Automatically generated ironic-api package
 
 Package: ironic-conductor
 Architecture: all
-Depends: rjil-cicd
-Description: ironic-conductor server package
- Automatically generated server package for ironic-conductor
+Depends: rjil-cicd (=${binary:Version})
+Description: ironic-conductor package
+ Automatically generated ironic-conductor package
+
+Package: ironic-common
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: ironic-common package
+ Automatically generated ironic-common package
+
+Package: python-cinderclient
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-cinderclient package
+ Automatically generated python-cinderclient package
+
+Package: python-glanceclient
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-glanceclient package
+ Automatically generated python-glanceclient package
+
+Package: python-ironic
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-ironic package
+ Automatically generated python-ironic package
+
+Package: python-keystoneclient
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-keystoneclient package
+ Automatically generated python-keystoneclient package
+
+Package: python-keystonemiddleware
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-keystonemiddleware package
+ Automatically generated python-keystonemiddleware package
+
+Package: python-neutronclient
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-neutronclient package
+ Automatically generated python-neutronclient package
+
+Package: python-novaclient
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-novaclient package
+ Automatically generated python-novaclient package
+
+Package: python-oslo.concurrency
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-oslo.concurrency package
+ Automatically generated python-oslo.concurrency package
+
+Package: python-oslo.config
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-oslo.config package
+ Automatically generated python-oslo.config package
+
+Package: python-oslo.db
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-oslo.db package
+ Automatically generated python-oslo.db package
+
+Package: python-oslo.messaging
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-oslo.messaging package
+ Automatically generated python-oslo.messaging package
+
+Package: python-posix-ipc
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-posix-ipc package
+ Automatically generated python-posix-ipc package
+
+Package: python-retrying
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-retrying package
+ Automatically generated python-retrying package
+
+Package: python-swiftclient
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-swiftclient package
+ Automatically generated python-swiftclient package
+
+Package: python-websockify
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-websockify package
+ Automatically generated python-websockify package
+
+Package: python-proliantutils
+Architecture: all
+Depends: rjil-cicd (=${binary:Version})
+Description: python-proliantutils package
+ Automatically generated python-proliantutils package
 

--- a/debian/control.stub
+++ b/debian/control.stub
@@ -9,18 +9,11 @@ Build-Depends: debhelper (>= 7),
                python-sphinx,
                python-prettytable,
                python-dev,
-               python-flake8,
-               python-pytest,
-               python-unittest2,
-               devscripts
 Standards-Version: 3.9.2
 
 Package: rjil-cicd
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}
-Provides: ${rjil:pkgs}
-Conflicts: ${rjil:pkgs}
-Replaces: ${rjil:pkgs}
 Description: Monolithic OpenStack deb package
  This is a monolithic deb package comprising of the following openstack modules
  * python-cincerclient

--- a/debian/rules
+++ b/debian/rules
@@ -30,9 +30,7 @@ override_dh_auto_build: debian/control $(patsubst %,build/%,$(PROJECTS))
 override_dh_auto_install: debian/control $(patsubst %,install/%,$(PROJECTS))
 
 clean/%: %/debian
-	pwd
 	cd $* && dh_auto_clean
-	pwd
 
 build/%: %/debian
 	cd $* && dh_auto_build

--- a/debian/rules
+++ b/debian/rules
@@ -23,37 +23,33 @@ export VERSION=1:$(PBR_VERSION)
 %:
 	dh $@ --with python2
 
-override_dh_auto_clean: debian/symlinks debian/control
-	for PROJ in $(PROJECTS); \
-	do \
-		cd $${PROJ} && dh_auto_clean && cd ..; \
-	done
+override_dh_auto_clean: debian/symlinks debian/control $(patsubst %,clean/%,$(PROJECTS))
 
-override_dh_auto_build: debian/symlinks debian/control
-	for PROJ in $(PROJECTS); \
-	do \
-		cd $${PROJ} && dh_auto_build && cd ..; \
-	done
+override_dh_auto_build: debian/symlinks debian/control $(patsubst %,build/%,$(PROJECTS))
+
+override_dh_auto_install: debian/symlinks debian/control $(patsubst %,install/%,$(PROJECTS))
+
+clean/%: %/debian
+	pwd
+	cd $* && dh_auto_clean
+	pwd
+
+build/%: %/debian
+	cd $* && dh_auto_build
+
+install/%: %/debian
+	cd $* && dh_auto_install
+
+%/debian:
+	ln -s ../debian $@
 
 debian/rjil-cicd.substvars: 
 	python -c 'import sys;print "rjil:pkgs="+", ".join(sys.argv[1:])' $$(cat debian/superseded-packages) >> debian/rjil-cicd.substvars
-
-override_dh_auto_install: debian/symlinks debian/control debian/rjil-cicd.substvars
-	for PROJ in $(PROJECTS); \
-	do \
-		cd $${PROJ} && dh_auto_install && cd ..; \
-	done
 
 debian/control: debian/control.stub debian/control.tmpl $(UPSTART_JOBS)
 	cp debian/control.stub debian/control
 	for s in $(SERVERS); do \
 		sed -e s@PKGNAME@$$s@g < debian/control.tmpl >> debian/control ; \
-	done
-
-debian/symlinks:
-	for proj in $(PROJECTS); \
-	do \
-		cd $${proj} && test -L debian || ln -s ../debian . && cd ..; \
 	done
 
 debian/chlog:
@@ -62,4 +58,4 @@ debian/chlog:
 	cat debian/changelog.git | while IFS= read line; do dch "$(line)"; done
 	dch -D $(DIST) -r ""
 
-.PHONY: debian/control debian/rjil-cicd.substvars debian/symlinks debian/chlog
+.PHONY: debian/control debian/rjil-cicd.substvars debian/symlinks debian/chlog $(patsubst %,clean/%,$(PROJECTS)) $(patsubst %,build/%,$(PROJECTS)) $(patsubst %,install/%,$(PROJECTS)) 

--- a/debian/rules
+++ b/debian/rules
@@ -23,11 +23,11 @@ export VERSION=1:$(PBR_VERSION)
 %:
 	dh $@ --with python2
 
-override_dh_auto_clean: debian/symlinks debian/control $(patsubst %,clean/%,$(PROJECTS))
+override_dh_auto_clean: debian/control $(patsubst %,clean/%,$(PROJECTS))
 
-override_dh_auto_build: debian/symlinks debian/control $(patsubst %,build/%,$(PROJECTS))
+override_dh_auto_build: debian/control $(patsubst %,build/%,$(PROJECTS))
 
-override_dh_auto_install: debian/symlinks debian/control $(patsubst %,install/%,$(PROJECTS))
+override_dh_auto_install: debian/control $(patsubst %,install/%,$(PROJECTS))
 
 clean/%: %/debian
 	pwd
@@ -58,4 +58,4 @@ debian/chlog:
 	cat debian/changelog.git | while IFS= read line; do dch "$(line)"; done
 	dch -D $(DIST) -r ""
 
-.PHONY: debian/control debian/rjil-cicd.substvars debian/symlinks debian/chlog $(patsubst %,clean/%,$(PROJECTS)) $(patsubst %,build/%,$(PROJECTS)) $(patsubst %,install/%,$(PROJECTS)) 
+.PHONY: debian/control debian/rjil-cicd.substvars debian/chlog $(patsubst %,clean/%,$(PROJECTS)) $(patsubst %,build/%,$(PROJECTS)) $(patsubst %,install/%,$(PROJECTS)) 

--- a/debian/rules
+++ b/debian/rules
@@ -41,10 +41,7 @@ install/%: %/debian
 %/debian:
 	ln -s ../debian $@
 
-debian/rjil-cicd.substvars: 
-	python -c 'import sys;print "rjil:pkgs="+", ".join(sys.argv[1:])' $$(cat debian/superseded-packages) >> debian/rjil-cicd.substvars
-
-debian/control: debian/control.stub $(patsubst %,debian/%.control,$(SERVERS))
+debian/control: debian/control.stub $(patsubst %,debian/%.control,$(SERVERS) $(shell cat debian/superseded-packages))
 	cat $^ > $@
 
 debian/%.control: debian/control.tmpl

--- a/debian/rules
+++ b/debian/rules
@@ -44,11 +44,11 @@ install/%: %/debian
 debian/rjil-cicd.substvars: 
 	python -c 'import sys;print "rjil:pkgs="+", ".join(sys.argv[1:])' $$(cat debian/superseded-packages) >> debian/rjil-cicd.substvars
 
-debian/control: debian/control.stub debian/control.tmpl $(UPSTART_JOBS)
-	cp debian/control.stub debian/control
-	for s in $(SERVERS); do \
-		sed -e s@PKGNAME@$$s@g < debian/control.tmpl >> debian/control ; \
-	done
+debian/control: debian/control.stub $(patsubst %,debian/%.control,$(SERVERS))
+	cat $^ > $@
+
+debian/%.control: debian/control.tmpl
+	sed -e s@PKGNAME@$*@g < $< > $@
 
 debian/chlog:
 	# Populate changelog here as clean target will be run.


### PR DESCRIPTION
It turns out that there's quite a few versioned dependencies on these
packages, so having them just be virtual won't suffice.