### PR TITLE
Determine and build package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -29,8 +29,8 @@ override_dh_auto_build: debian/control $(patsubst %,build/%,$(PROJECTS))
 
 override_dh_auto_install: debian/control $(patsubst %,install/%,$(PROJECTS)) debian/rjil-cicd.substvars
 
-clean/%: %/debian
-	cd $* && dh_auto_clean
+clean/%: %/debian debian/chlog
+	#cd $* && dh_auto_clean
 
 build/%: %/debian
 	cd $* && dh_auto_build

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,12 @@ export SKIP_GENERATE_AUTHORS=1
 export SKIP_WRITE_GIT_CHANGELOG=1
 
 export DIST=$(shell dpkg-parsechangelog  | grep ^Distribution: | cut -d ' ' -f2)
-export VERSION=1:$(PBR_VERSION)
+
+VERSION=1:$(PBR_VERSION)
+ifndef BUILD_NUMBER
+VERSION=2:$(PBR_VERSION)
+BUILD_NUMBER=$(shell date +%s)
+endif
 
 
 %:


### PR DESCRIPTION
    Determine and build package
    
    When run under Jenkins, we get the BUILD_NUMBER environment variable.
    That is what is already build used, when formatting the changelog.
    
    In this commit, we are re-using the same environment variable. If the
    variable is unset, it is safe to assume that we are being built on a
    developer box. In that case, we set the version accordingly.
    
    Repetitive builds on the developer box are guaranteed to of >N version


For commit: 4e23ca97cf23c0477419a6b3a263734456ea62bc
    Call changelog updation in the clean target. Also don't do actual dh_auto_clean because the -nc option in dpkg is not behaving proper. Once that is figured out, we can get back to doing dh_auto_clean again
